### PR TITLE
Enhance Vite library tooling

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -4,7 +4,6 @@
         "effect": "catalog:"
     },
     "devDependencies": {
-        "typescript": "catalog:",
         "vite": "catalog:"
     },
     "exports": {
@@ -23,12 +22,12 @@
     },
     "name": "@parametric-portal/theme",
     "scripts": {
-        "build": "vite build",
-        "check": "biome check .",
-        "dev": "vite dev --host",
-        "preview": "vite preview --host",
-        "test": "vitest run --passWithNoTests",
-        "typecheck": "tsc --project tsconfig.json --noEmit"
+        "build": "pnpm exec vite build",
+        "check": "pnpm exec biome ci .",
+        "dev": "pnpm exec vite dev --host",
+        "preview": "pnpm exec vite preview --host",
+        "test": "pnpm exec vitest run --passWithNoTests",
+        "typecheck": "pnpm exec tsc --project tsconfig.json --noEmit"
     },
     "type": "module",
     "version": "0.0.1"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,8 +7,6 @@
         "zustand": "catalog:"
     },
     "devDependencies": {
-        "@types/uuid": "catalog:",
-        "typescript": "catalog:",
         "vite": "catalog:"
     },
     "exports": {
@@ -35,12 +33,12 @@
     },
     "name": "@parametric-portal/types",
     "scripts": {
-        "build": "vite build",
-        "check": "biome check .",
-        "dev": "vite dev --host",
-        "preview": "vite preview --host",
-        "test": "vitest run --passWithNoTests",
-        "typecheck": "tsc --project tsconfig.json --noEmit"
+        "build": "pnpm exec vite build",
+        "check": "pnpm exec biome ci .",
+        "dev": "pnpm exec vite dev --host",
+        "preview": "pnpm exec vite preview --host",
+        "test": "pnpm exec vitest run --passWithNoTests",
+        "typecheck": "pnpm exec tsc --project tsconfig.json --noEmit"
     },
     "type": "module",
     "version": "0.0.1"


### PR DESCRIPTION
## Summary
- add shared library plugin factory to reuse compression, inspect, image optimizer, and visualizer tooling in Vite builds
- tune library build outputs to disable compressed size reporting and surface shared plugin stacks
- align package manifests with pnpm exec scripts and declare Vite tooling in workspace packages

## Testing
- pnpm check
- pnpm exec nx run-many -t typecheck --output-style=stream


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924223d0aa883219271893fab73f474)