### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -11,7 +11,10 @@
         "version": "22.2.0-canary.20251125-7e00ec4"
     },
     "namedInputs": {
-        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "default": [
+            "{projectRoot}/**/*",
+            "sharedGlobals"
+        ],
         "production": [
             "default",
             "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -37,11 +40,14 @@
             "sharedGlobals"
         ]
     },
-    "nxCloudId": "6927da8c08e1be8a3c0123aa",
+    "nxCloudId": "6929c006315634b45342f623",
     "parallel": 4,
     "plugins": [
         {
-            "exclude": ["vite.config.ts", "vitest.config.ts"],
+            "exclude": [
+                "vite.config.ts",
+                "vitest.config.ts"
+            ],
             "options": {
                 "buildTargetName": "build",
                 "previewTargetName": "preview",
@@ -55,7 +61,9 @@
     "targetDefaults": {
         "analyze": {
             "cache": true,
-            "dependsOn": ["build"],
+            "dependsOn": [
+                "build"
+            ],
             "executor": "nx:run-commands",
             "options": {
                 "command": "npx serve .vite -l 8080"
@@ -63,20 +71,32 @@
         },
         "build": {
             "cache": true,
-            "dependsOn": ["^build"],
-            "inputs": ["production", "^production"],
-            "outputs": ["{projectRoot}/dist"]
+            "dependsOn": [
+                "^build"
+            ],
+            "inputs": [
+                "production",
+                "^production"
+            ],
+            "outputs": [
+                "{projectRoot}/dist"
+            ]
         },
         "check": {
             "cache": true,
-            "inputs": ["default", "sharedGlobals"]
+            "inputs": [
+                "default",
+                "sharedGlobals"
+            ]
         },
         "dev": {
             "cache": false
         },
         "inspect:build": {
             "cache": false,
-            "dependsOn": ["build"],
+            "dependsOn": [
+                "build"
+            ],
             "executor": "nx:run-commands",
             "options": {
                 "command": "npx serve .vite-inspect -l 8081"
@@ -91,7 +111,9 @@
         },
         "mutate": {
             "cache": false,
-            "dependsOn": ["build"],
+            "dependsOn": [
+                "build"
+            ],
             "executor": "nx:run-commands",
             "options": {
                 "command": "stryker run --incremental --testRunner vitest --coverageAnalysis perTest --reporters html,clear-text,progress --mutate 'packages/*/src/**/*.ts' --mutate '!packages/*/src/**/*.d.ts' --mutate '!packages/*/src/**/*.spec.ts'"
@@ -115,17 +137,29 @@
         },
         "test": {
             "cache": true,
-            "inputs": ["default", "^production"],
-            "outputs": ["{projectRoot}/coverage"]
+            "inputs": [
+                "default",
+                "^production"
+            ],
+            "outputs": [
+                "{projectRoot}/coverage"
+            ]
         },
         "typecheck": {
             "cache": true,
-            "dependsOn": ["^typecheck"],
-            "inputs": ["typescript", "sharedGlobals"]
+            "dependsOn": [
+                "^typecheck"
+            ],
+            "inputs": [
+                "typescript",
+                "sharedGlobals"
+            ]
         },
         "validate:compression": {
             "cache": false,
-            "dependsOn": ["build"],
+            "dependsOn": [
+                "build"
+            ],
             "executor": "nx:run-commands",
             "options": {
                 "commands": [
@@ -137,5 +171,8 @@
         }
     },
     "useInferencePlugins": true,
-    "workspaceLayout": { "appsDir": "apps", "libsDir": "packages" }
+    "workspaceLayout": {
+        "appsDir": "apps",
+        "libsDir": "packages"
+    }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6927da8c08e1be8a3c0123aa/workspaces/6929c006315634b45342f623

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.